### PR TITLE
Expand balance/hardware.md with linkage, wiring, and control-loop details

### DIFF
--- a/balance/hardware.md
+++ b/balance/hardware.md
@@ -21,28 +21,320 @@ It's the same feel as the pendulum sim, but the unstable axis is "ball wants to 
 | Part | Where | Approx S$ |
 |---|---|---|
 | SG90 micro-servo (or MG90S for metal gears / less slop) | Sim Lim — hobby electronics shops on L3 / L4 | 3–6 |
-| HC-SR04 ultrasonic distance sensor (or VL53L0X laser ToF — see gotchas) | Sim Lim, same shops | 2–8 |
+| VL53L0X laser ToF distance sensor (preferred over HC-SR04 ultrasonic) | Sim Lim, same shops | ~8 |
 | Ping-pong ball | Decathlon / any sports shop | 1 |
 | Jumper wires + breadboard | Probably already on hand | – |
-| Arduino Uno / Nano or ESP32 | Already on hand | – |
+| Raspberry Pi (any model with 40-pin header) | Already on hand | – |
 | 5 V power (USB is fine for an SG90) | Already on hand | – |
 
 ## What to 3D-print
 
 - A **beam** with a small V-groove or rail down the length so the ball tracks straight and doesn't fall off sideways. Length ~20–30 cm.
-- A **servo horn coupling** that converts the servo's rotation into a tilt of the beam. Keep the pivot close to the beam's centre of mass so the servo isn't fighting gravity.
-- A **base / stand** that holds the servo, the pivot bearing (or just a friction pivot), and the sensor at one end pointing along the beam toward the ball.
+- **Pivot post(s)** that hold the beam on its own bearing (a skate bearing, a brass bushing, or an M3 screw will do).
+- A **servo mount** that holds the servo upright on the base, off to one side of the beam.
+- A **push-rod** (or just use a stiff piece of straight wire bent into a Z at each end — paperclip works for prototyping).
+- A **base plate** to tie it all together.
 
 Total print time roughly 1–2 hours.
 
-## Two gotchas to know going in
+## The sensor: VL53L0X (laser time-of-flight)
 
-1. **Ultrasonic sensors have a ~2 cm minimum range.** Position the sensor so the ball never gets closer than that. Or use a **VL53L0X laser ToF sensor** instead (~S$8, also at Sim Lim) — works down to ~3 cm, faster sample rate, less noisy.
-2. **SG90 servos have backlash and limited resolution.** This is *good news* for learning — the imperfect actuator makes PID tuning feel real instead of toy-clean. If it bothers you later, swap to MG90S (metal gears, ~S$2 more).
+There are two common cheap distance-sensor options for this build. The doc previously listed the HC-SR04 ultrasonic; we're going with the VL53L0X instead.
+
+**HC-SR04 (ultrasonic).** A ~40 kHz sound pulse and an echo timer. Looks like a board with two metal cylinders ("eyes"). Range 2 cm – 4 m, ~S$2, dead-simple Trig/Echo pins on 5 V. Downsides: that 2 cm dead zone bites on a short beam, readings are noisy, and it reflects oddly off curved/soft surfaces like a ping-pong ball.
+
+**VL53L0X (laser ToF).** Same idea but with an invisible IR laser instead of sound. A small chip with an emitter and a receiver window. Range ~3 cm – 1.2 m, much more precise, faster (~50 Hz), and indifferent to surface acoustics. ~S$8, talks over I²C (SDA/SCL), runs on 3.3 V or 5 V. The tradeoff is one extra concept to learn (I²C) versus the dead-simple Trig/Echo of the ultrasonic.
+
+For this project the VL53L0X is worth the extra S$5 — cleaner data and faster loop are both more useful than the savings.
+
+## The processor: Raspberry Pi vs. ESP32
+
+Either works. The honest tradeoffs:
+
+**ESP32** is a microcontroller. The PID loop runs deterministically, PWM to the servo is hardware-clean, boots in milliseconds. ~S$8 if you don't already own one. Best choice on technical merit.
+
+**Raspberry Pi** is a full Linux computer. Two consequences:
+
+- Loop timing has *some* jitter because Linux preempts you. For a 50–200 Hz ball-on-beam loop this is fine — the ball doesn't move that fast — you just won't get the rock-solid 1 kHz an ESP32 could squeeze out.
+- Software PWM on a Pi jitters enough that an SG90 visibly twitches. Fix: use `pigpio` (DMA-based PWM, very stable), use GPIO 18 which has hardware PWM, or add a **PCA9685** servo-driver board over I²C (~S$3 at Sim Lim, overkill for one servo but bulletproof).
+
+Upside of the Pi: you write Python directly, you can `ssh` in, log to disk, plot live with matplotlib, reuse your sim code almost verbatim. For learning, that's nicer.
+
+**Going with the Pi.** Servo driven from GPIO 18 via `pigpio`; ~100 Hz loop.
+
+## Wiring
+
+![Wiring diagram](img/wiring.svg)
+
+### VL53L0X → Pi (I²C)
+
+| VL53L0X pin | Pi pin (physical) | Pi function |
+|---|---|---|
+| VIN | pin 1 | 3.3 V |
+| GND | pin 6 | GND |
+| SDA | pin 3 | GPIO 2 (I²C1 SDA) |
+| SCL | pin 5 | GPIO 3 (I²C1 SCL) |
+
+XSHUT and GPIO1 on the breakout — leave disconnected.
+
+Then:
+
+```
+sudo raspi-config        # Interface Options → I²C → Enable, then reboot
+sudo apt install i2c-tools python3-pip
+i2cdetect -y 1           # should show "29" — that's the sensor's address
+pip install adafruit-circuitpython-vl53l0x
+```
+
+Quick sanity test:
+
+```python
+import board, busio, adafruit_vl53l0x
+i2c = busio.I2C(board.SCL, board.SDA)
+sensor = adafruit_vl53l0x.VL53L0X(i2c)
+while True:
+    print(sensor.range, "mm")
+```
+
+### SG90 → Pi (PWM)
+
+| SG90 wire | Pi pin | Notes |
+|---|---|---|
+| Brown (GND) | pin 9 (or any GND) | must share ground with Pi |
+| Red (5 V) | pin 2 (5 V) | OK for one SG90; if it browns out the Pi, use a separate 5 V supply with GND tied to Pi GND |
+| Orange (signal) | pin 12 (GPIO 18) | hardware PWM channel |
+
+Then on the Pi:
+
+```
+sudo apt install pigpio python3-pigpio
+sudo systemctl enable --now pigpiod
+```
+
+```python
+import pigpio
+pi = pigpio.pi()
+pi.set_servo_pulsewidth(18, 1500)   # 1500 µs = center; 500 = full one way, 2500 = full the other
+```
+
+## Mechanical architecture: the linkage
+
+A foot-long beam mounted *directly* on an SG90 horn will eventually strip the servo's plastic gears — not because the servo is short on torque (it has ~50× more than it needs), but because the **side load** on the tiny output shaft is what hobby servos are weakest against. The fix is mechanical, not "buy a bigger servo":
+
+- **The beam pivots on its own bearing**, on a post. That bearing carries the beam's weight.
+- **The servo lives separately on the base** and connects to one end of the beam via a short rigid **push-rod**.
+- The servo never carries the beam. Its job is purely "push the rod up a bit / pull it down a bit."
+
+Think of it like a drawbridge: the bridge is hinged on the bank, and a winch on the bank raises/lowers the far end via a stiff rod.
+
+### Overview
+
+![Linkage overview](img/linkage-overview.svg)
+
+### How it converts rotation into tilt
+
+The rod attaches to the servo horn at a point that's *offset* from the servo's rotation axis. As the horn rotates a few degrees, that attach point swings up or down in a small arc — effectively translating the rotation into linear motion of the rod. The rod then pushes or pulls the far end of the beam, which pivots about its own bearing.
+
+![Linkage in motion](img/linkage-motion.svg)
+
+### If you want to skip the linkage
+
+If you really want to mount the beam straight on the servo (simpler, less to print), swap the servo:
+
+| Servo | Torque | Gears | Sim Lim ~S$ | Verdict for direct-mount foot-long beam |
+|---|---|---|---|---|
+| SG90 | 1.8 kg·cm | plastic | 3 | Works briefly, gears wear from side load |
+| **MG90S** | 2.2 kg·cm | **metal** | 5 | Drop-in replacement, same size, fixes the gear-strip problem |
+| MG996R | 11 kg·cm | metal | 8 | Overkill, bigger footprint, bulletproof |
+
+Recommendation: keep the SG90 and design with a linkage. You'll learn more from getting the mechanical architecture right than from throwing a beefier servo at a side-loading problem.
+
+## The control loop
+
+![Control loop diagram](img/control-loop.svg)
+
+There is no event hook. The Pi just polls the sensor ~100 times per second and runs four steps every tick:
+
+```python
+while True:
+    distance = sensor.range            # 1. read
+    error = target - distance          # 2. compare
+    output = pid.update(error, dt)     # 3. think
+    servo.set_angle(90 + output)       # 4. act
+    sleep(dt)                          # 5. wait one tick
+```
+
+That polling loop *is* the controller.
+
+### From PID output to servo PWM
+
+The PID emits a single number per tick. You decide what it represents — for a servo the cleanest choice is **degrees of beam tilt from level**. Then convert degrees to a pulse width.
+
+The SG90 takes a pulse-width signal: a square wave at 50 Hz where the *width of the high pulse* tells it where to go.
+
+- **500 µs pulse → 0°**
+- **1500 µs pulse → 90°** (center)
+- **2500 µs pulse → 180°**
+
+Linear, so: `pulse_us = 500 + (angle / 180) × 2000`, which simplifies near center to `pulse_us ≈ 1500 + (angle − 90) × 11.1`.
+
+Hand the result to `pi.set_servo_pulsewidth(18, pulse_us)`; pigpio generates the pulse train in the background via DMA.
+
+### Full loop
+
+```python
+import time, pigpio, board, busio, adafruit_vl53l0x
+from balance.pid import PID
+
+SERVO_PIN = 18
+TARGET_MM = 125
+DT = 0.02                     # 50 Hz loop
+TILT_LIMIT_DEG = 20
+
+def angle_to_pulse_us(deg):
+    deg = max(90 - TILT_LIMIT_DEG, min(90 + TILT_LIMIT_DEG, deg))
+    return int(500 + (deg / 180) * 2000)
+
+i2c = busio.I2C(board.SCL, board.SDA)
+sensor = adafruit_vl53l0x.VL53L0X(i2c)
+pi = pigpio.pi()
+pid = PID(kp=0.3, ki=0.0, kd=0.05)
+
+while True:
+    distance = sensor.range
+    error = TARGET_MM - distance
+    tilt_deg = pid.update(error, DT)
+    pi.set_servo_pulsewidth(SERVO_PIN, angle_to_pulse_us(90 + tilt_deg))
+    time.sleep(DT)
+```
+
+The PID doesn't know its output is "degrees" — *you* decide that by how you scale Kp. If Kp = 0.3 and the error is in mm, then a 50 mm error produces a 15° tilt command. Tune Kp until that mapping feels right.
+
+## Loop rate, actuator lag, and why fast ticks are good
+
+An SG90 takes ~100 ms to swing 60°. In one 10 ms tick at 100 Hz, the servo can only physically move ~6°. That sounds like the controller is sending commands faster than the actuator can execute them — and it is. **That's the intended design.**
+
+Each PID output is not "go to this position and arrive there before I ask again"; it's **"this is the position you should currently be heading toward."** The servo doesn't need to *complete* each move — it just bends its trajectory toward the latest target. Because PID outputs change smoothly, each new target is only a tiny adjustment from the previous one, and the servo ends up tracing a continuous curve.
+
+The servo's own slowness acts as a low-pass filter on your commands. That's a feature.
+
+### What actually constrains the tick rate
+
+```
+plant dynamics  >>  loop period  ~  actuator response  >>  sensor sample time
+(~500 ms)           (10 ms)         (~100 ms)              (~30 ms for VL53L0X)
+```
+
+- **Too slow → ball escapes.** Rule of thumb: sample 10–20× faster than the *plant's* dynamics — the ball, not the servo. The ball takes ~half a second to roll off; anything below ~20 Hz feels sluggish, ~100 Hz is comfortable.
+- **Too fast → noise amplification.** At 1000 Hz the D-term starts differentiating sensor noise and producing twitchy commands. The servo will mostly smooth them out, but you waste power and wear the gears.
+
+The loop period sits *below* the actuator response on purpose. The servo being "behind" is the system integrating your stream of small corrections into smooth motion.
+
+## Rate limiting and low-pass filtering
+
+Two tools for taming the signal between PID and servo. Both are 2–3 line additions.
+
+### Rate limiter — hard cap on per-tick change
+
+Caps how much the commanded angle is allowed to move in one tick.
+
+```python
+MAX_DEG_PER_TICK = 2.0    # at 100 Hz → 200 °/s, roughly the SG90's actual speed
+commanded_angle = 90.0    # initial state, OUTSIDE the loop
+
+def rate_limit(target, current, max_step):
+    delta = target - current
+    if delta >  max_step: return current + max_step
+    if delta < -max_step: return current - max_step
+    return target
+
+# inside the loop:
+desired = 90 + tilt_deg
+commanded_angle = rate_limit(desired, commanded_angle, MAX_DEG_PER_TICK)
+pi.set_servo_pulsewidth(SERVO_PIN, angle_to_pulse_us(commanded_angle))
+```
+
+### Low-pass filter — exponential moving average (EMA)
+
+Blends each new command with the previous filtered value.
+
+```python
+ALPHA = 0.3               # 0 = output frozen, 1 = no filtering
+filtered_angle = 90.0     # initial state, OUTSIDE the loop
+
+# inside the loop:
+desired = 90 + tilt_deg
+filtered_angle = ALPHA * desired + (1 - ALPHA) * filtered_angle
+pi.set_servo_pulsewidth(SERVO_PIN, angle_to_pulse_us(filtered_angle))
+```
+
+The line `new = α·desired + (1−α)·old` is equivalent to a first-order RC low-pass, with cutoff frequency ≈ `α · loop_rate / (2π)`. At 100 Hz with α = 0.3, anything wiggling faster than ~5 Hz gets squashed.
+
+### Which one when
+
+| Symptom | Reach for |
+|---|---|
+| Servo trying to slam from one extreme to the other on a big error | **Rate limiter** |
+| Servo buzzing/twitching from noisy sensor or a hot D-term | **Low-pass filter** |
+| Both | Stack them: filter first, then rate-limit the result |
+
+### Gotcha: filtering adds phase lag
+
+Anything between the PID and the servo *delays* the controller's response. Delay is the enemy of stability — too much and the loop oscillates. Filter only as much as you need.
+
+A subtler trick that's often better: filter the **sensor reading** instead of the output. That kills noise at the source before the D-term amplifies it, and costs less phase margin:
+
+```python
+filtered_distance = ALPHA * sensor.range + (1 - ALPHA) * filtered_distance
+error = TARGET_MM - filtered_distance
+tilt_deg = pid.update(error, DT)
+```
+
+**Order of operations:**
+1. Tune the PID with raw inputs and outputs first. See if it even needs filtering.
+2. If the D-term makes the servo buzz → low-pass the *sensor*, α around 0.3–0.5.
+3. If the servo hits mechanical limits on large errors → add a rate limiter on the *output*.
+4. If you still see oscillation: the issue is gains, not filtering. Lower Kp, lower Kd. Don't filter your way out of bad tuning.
+
+## Limit cycling at balance
+
+At the setpoint, sensor noise causes the servo to twitch with micro-commands forever. The system is mechanically still but the controller is hallucinating motion. This is called **limit cycling**.
+
+When the ball is genuinely at center, the sensor reads e.g. `124, 126, 125, 127, 123, 125…` — ±2 mm of jitter. Each PID term sees this differently:
+
+- **P-term:** error is ~±2 mm. Output is `Kp · 2` — tiny, mostly harmless.
+- **I-term:** integrates zero-mean noise → averages to ~zero. Innocent.
+- **D-term:** the villain. `derivative = (Δ error) / dt`. A 2 mm flicker over 10 ms reads as **200 mm/s** of phantom ball velocity. Multiply by Kd and the output spikes. Next tick the noise flips sign and the spike flips with it. That's the buzz.
+
+### Fixes, in order
+
+1. **Low-pass the sensor reading.** (See above.) Single most effective.
+2. **Deadband on the error.** Declare victory inside ±DEADBAND_MM:
+   ```python
+   DEADBAND_MM = 3
+   if abs(error) < DEADBAND_MM:
+       error = 0
+   ```
+   The cost is a small steady-state offset (ball can sit `DEADBAND_MM` off center before correcting).
+3. **Filter the D-term specifically.** Keep P/I fast, smooth only the derivative:
+   ```python
+   filtered_d = ALPHA_D * raw_derivative + (1 - ALPHA_D) * filtered_d
+   ```
+4. **Lower Kd.** If you're fighting noise with filters, maybe the gain itself is too aggressive.
+5. **The servo's own deadband saves you a bit for free.** SG90s typically ignore pulse-width changes smaller than ~1–2 µs (~0.1°), so the very smallest commands get filtered by physics.
+
+### The mental shift
+
+Treat the resting state as a **range**, not a point. "At center" means "within ±3 mm of center, with bounded twitch." A perfectly still servo at balance is not the goal — a quietly-still-enough servo is. Limit cycling becomes a problem only when the twitch is visible, audible, or starts wearing the servo gears. Below that, leave it alone.
+
+## Two gotchas (now condensed)
+
+1. **VL53L0X dead zone.** Works down to ~3 cm — keep the ball from getting closer than that. Much better than the HC-SR04's 2 cm minimum and also less noisy / faster.
+2. **SG90 backlash.** ~1–2° of slop in the gear train. On a 15 cm lever, that's ~3–5 mm of dead zone at the tip. *Good news for learning* — the imperfect actuator makes PID tuning feel real instead of toy-clean. If it bothers you later, swap to MG90S (metal gears, ~S$2 more).
 
 ## Porting the simulation code
 
-Once it's mechanically working, the controller code in `balance/pid.py` and `balance/recovery.py` ports almost directly to Arduino / MicroPython / CircuitPython. The loop shape is the same:
+The controller code in `balance/pid.py` and `balance/recovery.py` ports almost directly. The loop shape is the same:
 
 ```
 loop:
@@ -54,9 +346,9 @@ loop:
 
 Things that change vs. the sim:
 
-- `dt` is your loop's real wall-clock period (`millis()` deltas on Arduino). The "tick rate" is now a real engineering parameter — too slow and the ball escapes.
-- Sensor noise is real. You may want a small low-pass filter on the measurement before feeding it to the PID.
-- The actuator (servo) has its own internal control loop, so you're really commanding a setpoint, not a torque. That's fine — PID doesn't care.
+- `dt` is your loop's real wall-clock period. The "tick rate" is now a real engineering parameter — too slow and the ball escapes.
+- Sensor noise is real. Low-pass the measurement before feeding it to the PID.
+- The actuator (servo) has its own internal control loop, so you're really commanding a setpoint, not a torque. PID doesn't care.
 - Gains will not be the same as the sim. Start from zero, raise Kp until it oscillates, back off, then add Kd, then Ki. Classic Ziegler-Nichols-ish hand-tuning.
 
 ## Suggested progression

--- a/balance/img/control-loop.svg
+++ b/balance/img/control-loop.svg
@@ -1,0 +1,69 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 320" font-family="-apple-system, system-ui, sans-serif" font-size="13">
+  <style>
+    .box   { fill: #fff; stroke: #000; stroke-width: 1.5; }
+    .plant { fill: #fef5e6; stroke: #000; stroke-width: 1.5; }
+    .ctl   { fill: #e6f0ff; stroke: #000; stroke-width: 1.5; }
+    .sens  { fill: #e8f5e8; stroke: #000; stroke-width: 1.5; }
+    .actu  { fill: #fde6e6; stroke: #000; stroke-width: 1.5; }
+    .lbl   { fill: #222; font-size: 13px; }
+    .note  { fill: #555; font-style: italic; font-size: 11px; }
+    .arrow { stroke: #000; stroke-width: 2; fill: none; marker-end: url(#a); }
+  </style>
+  <defs>
+    <marker id="a" markerWidth="10" markerHeight="10" refX="9" refY="3" orient="auto">
+      <polygon points="0,0 9,3 0,6" fill="#000"/>
+    </marker>
+  </defs>
+
+  <text x="450" y="28" text-anchor="middle" font-size="15" font-weight="600" class="lbl">Control loop — what runs every 10 ms</text>
+
+  <!-- Setpoint -->
+  <text x="40" y="135" class="lbl">target</text>
+  <text x="40" y="151" class="note">(125 mm)</text>
+  <line x1="90" y1="140" x2="138" y2="140" class="arrow"/>
+
+  <!-- Summing junction -->
+  <circle cx="155" cy="140" r="17" class="box"/>
+  <text x="155" y="145" text-anchor="middle" class="lbl">−</text>
+  <text x="155" y="180" text-anchor="middle" class="note">error</text>
+
+  <!-- PID box -->
+  <rect x="200" y="115" width="130" height="50" class="ctl"/>
+  <text x="265" y="140" text-anchor="middle" font-weight="600" class="lbl">PID</text>
+  <text x="265" y="158" text-anchor="middle" class="note">Kp · e + Ki · ∫e + Kd · de/dt</text>
+  <line x1="172" y1="140" x2="198" y2="140" class="arrow"/>
+
+  <!-- output -->
+  <text x="345" y="132" class="note">tilt deg</text>
+
+  <!-- angle → PWM -->
+  <rect x="350" y="115" width="130" height="50" class="ctl"/>
+  <text x="415" y="140" text-anchor="middle" font-weight="600" class="lbl">angle → pulse µs</text>
+  <text x="415" y="158" text-anchor="middle" class="note">500 + (deg/180)·2000</text>
+  <line x1="330" y1="140" x2="348" y2="140" class="arrow"/>
+
+  <!-- Servo -->
+  <rect x="500" y="115" width="120" height="50" class="actu"/>
+  <text x="560" y="140" text-anchor="middle" font-weight="600" class="lbl">SG90 servo</text>
+  <text x="560" y="158" text-anchor="middle" class="note">tilts beam</text>
+  <line x1="480" y1="140" x2="498" y2="140" class="arrow"/>
+
+  <!-- Plant -->
+  <rect x="640" y="115" width="160" height="50" class="plant"/>
+  <text x="720" y="140" text-anchor="middle" font-weight="600" class="lbl">beam + ball + gravity</text>
+  <text x="720" y="158" text-anchor="middle" class="note">(physics, in the real world)</text>
+  <line x1="620" y1="140" x2="638" y2="140" class="arrow"/>
+
+  <!-- Sensor -->
+  <rect x="640" y="220" width="160" height="50" class="sens"/>
+  <text x="720" y="245" text-anchor="middle" font-weight="600" class="lbl">VL53L0X sensor</text>
+  <text x="720" y="263" text-anchor="middle" class="note">reports ball distance (mm)</text>
+
+  <!-- Feedback loop -->
+  <line x1="720" y1="165" x2="720" y2="218" class="arrow"/>
+  <line x1="640" y1="245" x2="155" y2="245" class="arrow"/>
+  <line x1="155" y1="245" x2="155" y2="159" class="arrow"/>
+
+  <!-- Loop period -->
+  <text x="450" y="295" text-anchor="middle" class="note">All five steps happen every tick. At 100 Hz that's once every 10 ms — forever.</text>
+</svg>

--- a/balance/img/linkage-motion.svg
+++ b/balance/img/linkage-motion.svg
@@ -1,0 +1,114 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 980 460" font-family="-apple-system, system-ui, sans-serif" font-size="12">
+  <style>
+    .lbl { fill: #222; }
+    .note { fill: #555; font-style: italic; font-size: 11px; }
+    .arrow { stroke: #d33; stroke-width: 2; fill: none; marker-end: url(#arr); }
+  </style>
+  <defs>
+    <marker id="arr" markerWidth="10" markerHeight="10" refX="8" refY="3" orient="auto">
+      <polygon points="0,0 9,3 0,6" fill="#d33"/>
+    </marker>
+  </defs>
+
+  <!-- Title -->
+  <text x="490" y="26" text-anchor="middle" font-size="15" font-weight="600" class="lbl">Linkage in motion — rotation in, tilt out</text>
+
+  <!-- ============ LEFT PANEL: horn rotated CCW, rod up, far end up ============ -->
+  <text x="240" y="58" text-anchor="middle" font-weight="600" class="lbl">Horn rotates CCW → rod pushes up → beam tilts right-end-up</text>
+
+  <!-- Base -->
+  <rect x="40" y="370" width="400" height="14" fill="#bdbdbd" stroke="#000"/>
+
+  <!-- Pivot post -->
+  <rect x="110" y="240" width="28" height="130" fill="#cfcfcf" stroke="#000"/>
+  <circle cx="124" cy="240" r="10" fill="#fff" stroke="#000" stroke-width="2"/>
+  <circle cx="124" cy="240" r="3" fill="#000"/>
+
+  <!-- Beam (tilted: left low, right high) -->
+  <!-- Center at pivot (124,240), tilt about pivot. Right end raised. -->
+  <!-- Beam goes from pivot to ~400 horizontal, tilted ~ -12 degrees -->
+  <g transform="rotate(-12 124 240)">
+    <rect x="124" y="230" width="290" height="16" fill="#d9b382" stroke="#000"/>
+  </g>
+  <!-- Ball rolls toward the lower (left) end - but pivot is at the left end, so ball goes left -->
+  <!-- For visual clarity: ball near left -->
+  <circle cx="155" cy="218" r="10" fill="#fff" stroke="#000" stroke-width="2"/>
+
+  <!-- Servo -->
+  <rect x="335" y="290" width="74" height="74" fill="#333" stroke="#000"/>
+  <text x="372" y="335" text-anchor="middle" fill="#fff" font-weight="600" font-size="12">SERVO</text>
+
+  <!-- Servo horn rotated CCW (attach point higher, also slightly left) -->
+  <circle cx="372" cy="290" r="5" fill="#888" stroke="#000"/>
+  <line x1="372" y1="290" x2="362" y2="252" stroke="#000" stroke-width="4"/>
+  <circle cx="362" cy="252" r="4" fill="#d33"/>
+
+  <!-- Push-rod from horn attach to beam right-end -->
+  <!-- Beam right end (after rotation): pivot+290 along -12deg from (124,240) -->
+  <!-- approx: x = 124 + 290*cos(-12) = 124 + 283.5 = 407.5; y = 240 + 290*sin(-12) = 240 - 60.3 = 179.7 -->
+  <!-- but we want rod to attach roughly at the beam, near right end at the same x as servo: use x=395, y=192 -->
+  <line x1="362" y1="252" x2="385" y2="195" stroke="#222" stroke-width="3"/>
+  <circle cx="385" cy="195" r="4" fill="#d33"/>
+
+  <!-- Direction arrows -->
+  <path d="M 362 285 A 18 18 0 0 1 358 268" class="arrow"/>
+  <text x="320" y="278" class="note" fill="#d33">rotate CCW</text>
+
+  <text x="395" y="245" class="note" fill="#d33">rod up ↑</text>
+
+  <!-- Pivot label -->
+  <text x="60" y="225" class="note">pivot</text>
+  <line x1="80" y1="228" x2="114" y2="238" class="arrow" style="marker-end:none;stroke:#777;stroke-width:1"/>
+
+  <!-- Ball motion -->
+  <text x="155" y="200" text-anchor="middle" class="note" fill="#d33">ball rolls ← downhill</text>
+
+  <!-- ============ RIGHT PANEL: horn rotated CW, rod down, far end down ============ -->
+  <text x="730" y="58" text-anchor="middle" font-weight="600" class="lbl">Horn rotates CW → rod pulls down → beam tilts right-end-down</text>
+
+  <!-- Base -->
+  <rect x="530" y="370" width="400" height="14" fill="#bdbdbd" stroke="#000"/>
+
+  <!-- Pivot post -->
+  <rect x="600" y="240" width="28" height="130" fill="#cfcfcf" stroke="#000"/>
+  <circle cx="614" cy="240" r="10" fill="#fff" stroke="#000" stroke-width="2"/>
+  <circle cx="614" cy="240" r="3" fill="#000"/>
+
+  <!-- Beam tilted: right end down, left end up - tilt +12 deg about pivot -->
+  <g transform="rotate(12 614 240)">
+    <rect x="614" y="230" width="290" height="16" fill="#d9b382" stroke="#000"/>
+  </g>
+
+  <!-- Ball rolls toward right (lower) -->
+  <circle cx="870" cy="285" r="10" fill="#fff" stroke="#000" stroke-width="2"/>
+
+  <!-- Servo -->
+  <rect x="825" y="290" width="74" height="74" fill="#333" stroke="#000"/>
+  <text x="862" y="335" text-anchor="middle" fill="#fff" font-weight="600" font-size="12">SERVO</text>
+
+  <!-- Servo horn rotated CW (attach point lower, to the right) -->
+  <circle cx="862" cy="290" r="5" fill="#888" stroke="#000"/>
+  <line x1="862" y1="290" x2="872" y2="320" stroke="#000" stroke-width="4"/>
+  <circle cx="872" cy="320" r="4" fill="#d33"/>
+
+  <!-- Push-rod from horn (lower) up to beam right end (lower than before) -->
+  <!-- Beam right end after +12 rotation: x = 614 + 290*cos(12) = 614 + 283.5 = 897.5; y = 240 + 290*sin(12) = 240 + 60.3 = 300 -->
+  <!-- Use beam attach point at x=872, y=290 (approx) -->
+  <line x1="872" y1="320" x2="872" y2="290" stroke="#222" stroke-width="3"/>
+  <circle cx="872" cy="290" r="4" fill="#d33"/>
+
+  <!-- Direction arrows -->
+  <path d="M 862 285 A 18 18 0 0 0 866 268" class="arrow"/>
+  <text x="868" y="266" class="note" fill="#d33">rotate CW</text>
+
+  <text x="880" y="312" class="note" fill="#d33">rod down ↓</text>
+
+  <text x="870" y="262" text-anchor="middle" class="note" fill="#d33">ball rolls → downhill</text>
+
+  <!-- Pivot label -->
+  <text x="555" y="225" class="note">pivot</text>
+  <line x1="575" y1="228" x2="604" y2="238" class="arrow" style="marker-end:none;stroke:#777;stroke-width:1"/>
+
+  <!-- Bottom takeaway -->
+  <text x="490" y="430" text-anchor="middle" class="lbl">Small servo rotation ⇒ small rod travel ⇒ beam tilt about its own pivot. Servo never carries the beam's weight.</text>
+</svg>

--- a/balance/img/linkage-overview.svg
+++ b/balance/img/linkage-overview.svg
@@ -1,0 +1,66 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 820 440" font-family="-apple-system, system-ui, sans-serif" font-size="13">
+  <style>
+    .lbl { fill: #222; }
+    .note { fill: #555; font-style: italic; font-size: 12px; }
+    .annotate { stroke: #777; stroke-width: 1; fill: none; }
+  </style>
+
+  <!-- Title -->
+  <text x="410" y="28" text-anchor="middle" font-size="16" font-weight="600" class="lbl">Ball-on-beam with linkage (side view, beam level)</text>
+
+  <!-- Base plate -->
+  <rect x="60" y="370" width="700" height="18" fill="#bdbdbd" stroke="#000"/>
+  <text x="410" y="408" text-anchor="middle" class="note">base plate</text>
+
+  <!-- Pivot post -->
+  <rect x="195" y="200" width="36" height="170" fill="#cfcfcf" stroke="#000"/>
+  <text x="213" y="425" text-anchor="middle" class="lbl">pivot post</text>
+
+  <!-- Pivot bearing -->
+  <circle cx="213" cy="200" r="14" fill="#fff" stroke="#000" stroke-width="2"/>
+  <circle cx="213" cy="200" r="4" fill="#000"/>
+  <line x1="213" y1="200" x2="120" y2="160" class="annotate"/>
+  <text x="116" y="156" text-anchor="end" class="lbl">pivot bearing</text>
+  <text x="116" y="172" text-anchor="end" class="note">(carries all beam weight)</text>
+
+  <!-- Beam -->
+  <rect x="213" y="180" width="430" height="22" fill="#d9b382" stroke="#000"/>
+  <!-- V-groove indicator on top -->
+  <polyline points="220,180 643,180" fill="none" stroke="#000" stroke-dasharray="2,3"/>
+  <text x="430" y="170" text-anchor="middle" class="lbl">BEAM (ball rolls in V-groove on top)</text>
+
+  <!-- Ball -->
+  <circle cx="370" cy="168" r="12" fill="#fff" stroke="#000" stroke-width="2"/>
+  <text x="370" y="148" text-anchor="middle" class="lbl">ball</text>
+
+  <!-- Servo body -->
+  <rect x="555" y="280" width="90" height="90" fill="#333" stroke="#000"/>
+  <text x="600" y="332" text-anchor="middle" fill="#fff" font-weight="600">SERVO</text>
+  <text x="600" y="350" text-anchor="middle" fill="#fff" font-size="11">SG90</text>
+
+  <!-- Servo shaft center -->
+  <circle cx="600" cy="280" r="6" fill="#888" stroke="#000"/>
+  <text x="660" y="284" class="lbl">servo shaft (rotation axis)</text>
+  <line x1="606" y1="280" x2="655" y2="280" class="annotate"/>
+
+  <!-- Servo horn (offset arm) -->
+  <line x1="600" y1="280" x2="600" y2="240" stroke="#000" stroke-width="5"/>
+  <circle cx="600" cy="240" r="5" fill="#d33"/>
+  <text x="660" y="244" class="lbl">horn attach point</text>
+  <text x="660" y="258" class="note">(offset from shaft)</text>
+
+  <!-- Push-rod -->
+  <line x1="600" y1="240" x2="600" y2="202" stroke="#222" stroke-width="3"/>
+  <text x="660" y="220" class="lbl">push-rod (rigid wire)</text>
+  <line x1="600" y1="220" x2="660" y2="216" class="annotate"/>
+
+  <!-- Beam attach point -->
+  <circle cx="600" cy="202" r="5" fill="#d33"/>
+
+  <!-- Side caption explaining motion -->
+  <text x="60" y="60" class="lbl" font-weight="600">How it works:</text>
+  <text x="60" y="80" class="lbl">1. Servo rotates its horn a few degrees.</text>
+  <text x="60" y="98" class="lbl">2. Horn's attach point swings up or down.</text>
+  <text x="60" y="116" class="lbl">3. Rigid rod transmits that motion to the beam end.</text>
+  <text x="60" y="134" class="lbl">4. Beam pivots around the bearing.</text>
+</svg>

--- a/balance/img/wiring.svg
+++ b/balance/img/wiring.svg
@@ -1,0 +1,143 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 860 520" font-family="-apple-system, system-ui, sans-serif" font-size="12">
+  <style>
+    .lbl { fill: #222; }
+    .pin { fill: #fff; stroke: #000; }
+    .wire-power { stroke: #d33; stroke-width: 2.5; fill: none; }
+    .wire-gnd   { stroke: #222; stroke-width: 2.5; fill: none; }
+    .wire-data  { stroke: #2a5; stroke-width: 2.5; fill: none; }
+    .wire-pwm   { stroke: #d80; stroke-width: 2.5; fill: none; }
+  </style>
+
+  <!-- Title -->
+  <text x="430" y="26" text-anchor="middle" font-size="15" font-weight="600" class="lbl">Wiring: Raspberry Pi ↔ VL53L0X ↔ SG90</text>
+
+  <!-- ============== RASPBERRY PI HEADER (left side) ============== -->
+  <rect x="60" y="60" width="180" height="420" fill="#0e7c3a" stroke="#000"/>
+  <text x="150" y="82" text-anchor="middle" fill="#fff" font-weight="600">Raspberry Pi (40-pin)</text>
+
+  <!-- Header pins, two columns -->
+  <!-- We'll only label the pins we use -->
+  <!-- Pin layout: physical 1-40, odd left col, even right col -->
+  <!-- Pin 1 (3.3V), Pin 2 (5V), Pin 3 (GPIO2 SDA), Pin 4 (5V), Pin 5 (GPIO3 SCL), Pin 6 (GND), -->
+  <!-- Pin 9 (GND), Pin 12 (GPIO18 PWM) -->
+
+  <!-- Generic gray pins everywhere -->
+  <g fill="#999">
+    <rect x="100" y="100" width="14" height="10"/><rect x="186" y="100" width="14" height="10"/>
+    <rect x="100" y="115" width="14" height="10"/><rect x="186" y="115" width="14" height="10"/>
+    <rect x="100" y="130" width="14" height="10"/><rect x="186" y="130" width="14" height="10"/>
+    <rect x="100" y="145" width="14" height="10"/><rect x="186" y="145" width="14" height="10"/>
+    <rect x="100" y="160" width="14" height="10"/><rect x="186" y="160" width="14" height="10"/>
+    <rect x="100" y="175" width="14" height="10"/><rect x="186" y="175" width="14" height="10"/>
+    <rect x="100" y="190" width="14" height="10"/><rect x="186" y="190" width="14" height="10"/>
+  </g>
+
+  <!-- Highlight pins we use, with labels -->
+  <!-- Pin 1 (3.3V) - left col, row 1 -->
+  <rect x="100" y="100" width="14" height="10" fill="#fbb"/>
+  <text x="96" y="109" text-anchor="end" class="lbl">Pin 1 · 3.3V</text>
+
+  <!-- Pin 3 (GPIO2 SDA) - left col, row 2 -->
+  <rect x="100" y="115" width="14" height="10" fill="#bfb"/>
+  <text x="96" y="124" text-anchor="end" class="lbl">Pin 3 · SDA (GPIO 2)</text>
+
+  <!-- Pin 5 (GPIO3 SCL) - left col, row 3 -->
+  <rect x="100" y="130" width="14" height="10" fill="#bfb"/>
+  <text x="96" y="139" text-anchor="end" class="lbl">Pin 5 · SCL (GPIO 3)</text>
+
+  <!-- Pin 6 (GND) - right col, row 3 -->
+  <rect x="186" y="130" width="14" height="10" fill="#ccc"/>
+  <text x="204" y="139" class="lbl">Pin 6 · GND</text>
+
+  <!-- Pin 2 (5V) - right col, row 1 -->
+  <rect x="186" y="100" width="14" height="10" fill="#fdc"/>
+  <text x="204" y="109" class="lbl">Pin 2 · 5V</text>
+
+  <!-- Pin 9 (GND) - left col, row 5 -->
+  <rect x="100" y="160" width="14" height="10" fill="#ccc"/>
+  <text x="96" y="169" text-anchor="end" class="lbl">Pin 9 · GND</text>
+
+  <!-- Pin 12 (GPIO18 PWM) - right col, row 6 -->
+  <rect x="186" y="175" width="14" height="10" fill="#fde"/>
+  <text x="204" y="184" class="lbl">Pin 12 · GPIO 18 (PWM)</text>
+
+  <!-- ...rest of header indicated... -->
+  <text x="150" y="225" text-anchor="middle" class="lbl" font-style="italic" fill="#fff">(other pins unused)</text>
+
+  <!-- ============== VL53L0X (top right) ============== -->
+  <rect x="500" y="80" width="220" height="120" fill="#2a4d8f" stroke="#000"/>
+  <text x="610" y="105" text-anchor="middle" fill="#fff" font-weight="600">VL53L0X (laser ToF sensor)</text>
+  <circle cx="540" cy="135" r="6" fill="#000"/>
+  <circle cx="560" cy="135" r="6" fill="#222"/>
+  <text x="610" y="160" text-anchor="middle" fill="#fff" font-size="11">emitter · receiver</text>
+
+  <!-- VL53L0X pins on bottom -->
+  <g>
+    <rect x="520" y="200" width="14" height="10" class="pin"/>
+    <text x="527" y="225" text-anchor="middle" class="lbl">VIN</text>
+
+    <rect x="560" y="200" width="14" height="10" class="pin"/>
+    <text x="567" y="225" text-anchor="middle" class="lbl">GND</text>
+
+    <rect x="600" y="200" width="14" height="10" class="pin"/>
+    <text x="607" y="225" text-anchor="middle" class="lbl">SDA</text>
+
+    <rect x="640" y="200" width="14" height="10" class="pin"/>
+    <text x="647" y="225" text-anchor="middle" class="lbl">SCL</text>
+  </g>
+
+  <!-- ============== SG90 (bottom right) ============== -->
+  <rect x="500" y="340" width="220" height="120" fill="#444" stroke="#000"/>
+  <text x="610" y="365" text-anchor="middle" fill="#fff" font-weight="600">SG90 micro-servo</text>
+  <rect x="600" y="380" width="40" height="40" fill="#888" stroke="#fff"/>
+  <circle cx="620" cy="400" r="6" fill="#fff"/>
+
+  <!-- SG90 wires from left side -->
+  <g>
+    <rect x="490" y="370" width="10" height="8" fill="#d33"/>
+    <text x="486" y="377" text-anchor="end" class="lbl">red (5V)</text>
+
+    <rect x="490" y="395" width="10" height="8" fill="#222"/>
+    <text x="486" y="402" text-anchor="end" class="lbl">brown (GND)</text>
+
+    <rect x="490" y="420" width="10" height="8" fill="#d80"/>
+    <text x="486" y="427" text-anchor="end" class="lbl">orange (signal)</text>
+  </g>
+
+  <!-- ============== WIRES ============== -->
+
+  <!-- Pi 3.3V (pin 1) -> VL53L0X VIN -->
+  <path d="M 114 105 Q 350 100 527 200" class="wire-power"/>
+  <text x="320" y="92" class="lbl" fill="#d33">3.3V → VIN</text>
+
+  <!-- Pi GND (pin 6) -> VL53L0X GND -->
+  <path d="M 186 135 Q 380 180 567 200" class="wire-gnd"/>
+  <text x="340" y="178" class="lbl">GND → GND</text>
+
+  <!-- Pi SDA (pin 3) -> VL53L0X SDA -->
+  <path d="M 114 120 Q 360 130 607 200" class="wire-data"/>
+  <text x="320" y="120" class="lbl" fill="#2a5">SDA → SDA</text>
+
+  <!-- Pi SCL (pin 5) -> VL53L0X SCL -->
+  <path d="M 114 135 Q 380 160 647 200" class="wire-data"/>
+  <text x="320" y="150" class="lbl" fill="#2a5">SCL → SCL</text>
+
+  <!-- Pi 5V (pin 2) -> SG90 red -->
+  <path d="M 200 105 Q 360 350 490 374" class="wire-power"/>
+  <text x="290" y="340" class="lbl" fill="#d33">5V → SG90 red</text>
+
+  <!-- Pi GND (pin 9) -> SG90 brown -->
+  <path d="M 114 165 Q 320 380 490 399" class="wire-gnd"/>
+  <text x="300" y="395" class="lbl">GND → SG90 brown</text>
+
+  <!-- Pi GPIO 18 (pin 12) -> SG90 orange -->
+  <path d="M 200 180 Q 360 420 490 424" class="wire-pwm"/>
+  <text x="300" y="430" class="lbl" fill="#d80">GPIO 18 → SG90 orange (PWM)</text>
+
+  <!-- Legend -->
+  <text x="60" y="500" class="lbl" font-weight="600">Legend:</text>
+  <line x1="125" y1="497" x2="155" y2="497" class="wire-power"/><text x="160" y="500" class="lbl">power</text>
+  <line x1="200" y1="497" x2="230" y2="497" class="wire-gnd"/><text x="235" y="500" class="lbl">ground</text>
+  <line x1="280" y1="497" x2="310" y2="497" class="wire-data"/><text x="315" y="500" class="lbl">I²C data</text>
+  <line x1="365" y1="497" x2="395" y2="497" class="wire-pwm"/><text x="400" y="500" class="lbl">PWM signal</text>
+</svg>


### PR DESCRIPTION
## Summary

- Folds the chat-driven discussion into `balance/hardware.md`: VL53L0X choice, Raspberry Pi + `pigpio` over ESP32, full wiring, the angle→PWM math, a complete control-loop script, why loop rate < actuator response is intentional, rate-limiter and EMA low-pass filter recipes, limit cycling at balance and how to suppress it, and the mechanical **linkage architecture** that lets an SG90 drive a foot-long beam without side-loading its plastic gears.
- Adds four SVG diagrams under `balance/img/`: `linkage-overview.svg` (side view of beam, pivot, servo, push-rod), `linkage-motion.svg` (two tilted states showing horn rotation → tilt), `wiring.svg` (Pi pinout → VL53L0X + SG90, color-coded by wire purpose), `control-loop.svg` (sensor → PID → servo → plant block diagram).
- No code, tests, or runtime behavior changed — docs and diagrams only.

## Test plan

- [ ] Render `balance/hardware.md` on GitHub and confirm all four SVGs display inline.
- [ ] Skim each new section for technical accuracy (Pi vs ESP32, wiring table, PWM math, filter recipes, limit-cycle fixes, linkage description).
- [ ] Open each SVG directly and confirm labels are readable and the diagram still makes sense at GitHub's rendered width.


---
_Generated by [Claude Code](https://claude.ai/code/session_017VcWhp3rwVQ9gPNrfoiGWJ)_